### PR TITLE
Add recent changes including a mechanism to distinguish between linear and nonlinear models

### DIFF
--- a/R/00_workhorse.R
+++ b/R/00_workhorse.R
@@ -220,7 +220,7 @@ workhorse <- function(
     } else {
       estim_results
     },
-                                 "Loading_estimates"     = Lambda * csem_model$measurement,
+                                 "Loading_estimates"      = Lambda * csem_model$measurement,
                                  "Weight_estimates"       = W$W,
                                  "Inner_weight_estimates" = W$E,
                                  "Construct_scores"       = H,

--- a/R/estimators_paths.R
+++ b/R/estimators_paths.R
@@ -221,15 +221,18 @@ estimatePathOLS <- function(
     } # END for k in vars_endo
   } # END if(.approach_nlhod = replace)
 
-  ## Structure results
-  names_path <- paste0(rep(names(coef), times = sapply(coef, length)), "~",
-                       unlist(sapply(coef, rownames)))
-
-  path_estimates  <- data.frame("Path" = names_path,
-                                "Estimate" = unlist(coef, use.names = FALSE))
+  ### Structure results --------------------------------------------------------
+  tm <- t(.csem_model$structural)
+  tm[which(tm == 1)] <- do.call(rbind, coef)
+  
+  # names_path <- paste0(rep(names(coef), times = sapply(coef, length)), "~",
+  #                      unlist(sapply(coef, rownames)))
+  # 
+  # path_estimates  <- data.frame("Path" = names_path,
+  #                               "Estimate" = unlist(coef, use.names = FALSE))
 
   ## Return result -------------------------------------------------------------
-  list("Path_estimates" = path_estimates, R2 = r2)
+  list("Path_estimates" = t(tm), R2 = r2)
 }
 
 # estimatePath2SLS <- function(

--- a/R/helper_model.R
+++ b/R/helper_model.R
@@ -78,6 +78,13 @@ parseModel <- function(.model) {
     type_of_construct  <- unique(tbl_measurement[, c("lhs", "op")])
     colnames(type_of_construct) <- c("Name", "Type")
     
+    ## Type of model (linear or non-linear)
+    
+    type_of_model <- if(any(grepl("\\.", names_constructs_all))) {
+      "Nonlinear"
+    } else {
+      "Linear"
+    }
     ### Construct matrices specifying the relationship between constructs,
     ### indicators and errors ----------------------------------------------------
     model_structural  <- matrix(0,
@@ -222,6 +229,7 @@ parseModel <- function(.model) {
       "measurement"        = model_measurement,
       "error_cor"          = model_error,
       "construct_type"     = type_of_construct,
+      "model_type"         = type_of_model,
       "vars_endo"          = rownames(model_ordered),
       "vars_exo"           = var_exo,
       "vars_explana"       = colnames(model_ordered)[colSums(model_ordered) != 0],

--- a/R/helper_model.R
+++ b/R/helper_model.R
@@ -214,15 +214,18 @@ parseModel <- function(.model) {
     # A cSEMModel objects contains all the information about the model and its
     # components such as the type of construct used
     
-    model_ls <- list("structural"         = model_structural,
-                     "structural_ordered" = model_ordered,
-                     "measurement"        = model_measurement,
-                     "error_cor"          = model_error,
-                     "construct_type"     = type_of_construct,
-                     "vars_endo"          = rownames(model_ordered),
-                     "vars_exo"           = var_exo,
-                     "vars_explana"       = colnames(model_ordered)[colSums(model_ordered) != 0],
-                     "explained_by_exo"   = explained_by_exo
+    model_ls <- list(
+      "structural"         = model_structural[
+        c(setdiff(names_constructs, rownames(model_ordered)), 
+          rownames(model_ordered)), ],
+      # "structural_ordered" = model_ordered, # not needed so far
+      "measurement"        = model_measurement,
+      "error_cor"          = model_error,
+      "construct_type"     = type_of_construct,
+      "vars_endo"          = rownames(model_ordered),
+      "vars_exo"           = var_exo,
+      "vars_explana"       = colnames(model_ordered)[colSums(model_ordered) != 0],
+      "explained_by_exo"   = explained_by_exo
     )
     class(model_ls) <- "cSEMModel"
     return(model_ls) 


### PR DESCRIPTION
Closes #31

Notable changes
- Mechanism to distinguish between linear an nonlinear models
- Path coefficients are no return in a matrix of the same dimension as `csem_model$structural` (J x K). This is for compatibility with other postestimation functions and in line with #22.